### PR TITLE
refactor(test): resolve jest mock and eslint violations

### DIFF
--- a/Milestones/milestone_10/milestone10Project/__tests__/gesture-demo-back-button.test.tsx
+++ b/Milestones/milestone_10/milestone10Project/__tests__/gesture-demo-back-button.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
+import { TouchableOpacity, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import GestureDemo from '../app/gesture-demo';
-import { ColorGestureDisplay } from '@/components/color-gesture-display';
+
+const mockReact = React;
+const mockTouchableOpacity = TouchableOpacity;
+const mockText = Text;
 
 jest.mock('expo-router', () => ({
   useRouter: jest.fn(),
@@ -13,14 +17,12 @@ jest.mock(`@/components/color-gesture-display`, () => ({
 }));
 
 jest.mock('@rneui/themed', () => {
-  const mockReact = require('react');
-  const { TouchableOpacity, Text } = require('react-native');
   return {
     Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
       mockReact.createElement(
-        TouchableOpacity,
+        mockTouchableOpacity,
         { onPress, testID: 'rneui-button' },
-        mockReact.createElement(Text, null, title)
+        mockReact.createElement(mockText, null, title)
       ),
     useTheme: () => ({
       theme: {


### PR DESCRIPTION
## Changes
This pull request makes minor improvements to the test setup in `gesture-demo-back-button.test.tsx` by refactoring how mocks are created for React Native components. This change helps ensure that the mocked components used in the test are consistent and easier to manage.

- Introduced `mockReact`, `mockTouchableOpacity`, and `mockText` variables to reference the respective modules, and updated the mock for `@rneui/themed` to use these variables instead of requiring them inline.
- Replace require() calls and unused imports in gesture-demo-back-button test to comply with jest mock scope and eslint rules